### PR TITLE
Tech Interview (Lawrence Z)

### DIFF
--- a/src/main/java/util/webdriver/BasePageActions.java
+++ b/src/main/java/util/webdriver/BasePageActions.java
@@ -48,6 +48,20 @@ public final class BasePageActions {
     }
 
     /**
+     * overloaded method to set data to visible element and press Enter key.
+     *
+     * @param elem Selenide element.
+     * @param data string text that should be filled to field.
+     * @param pressEnter true if Enter key should be pressed.
+     */
+    public static void setDataToField(SelenideElement elem, String data, boolean pressEnter) {
+        elem.shouldBe(exist, Duration.ofMillis(BROWSER_TIMEOUT)).setValue(data);
+        if (pressEnter) {
+            elem.shouldBe(exist, Duration.ofMillis(BROWSER_TIMEOUT)).pressEnter();
+        }
+    }
+
+    /**
      * wait for n-seconds for the elent existing status.
      * @param element Selenide element.
      * @param timeout long time waiting for element exist.

--- a/src/test/java/com/page/TodomvcPage.java
+++ b/src/test/java/com/page/TodomvcPage.java
@@ -1,0 +1,81 @@
+package com.page;
+
+import com.codeborne.selenide.ElementsCollection;
+import com.codeborne.selenide.SelenideElement;
+import org.openqa.selenium.support.FindBy;
+
+import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Selenide.$;
+import static util.webdriver.BasePageActions.*;
+
+public class TodomvcPage {
+	private static final String URL = "https://todomvc.com/examples/react/#/";
+
+	@FindBy(css = "header>h1")
+	private SelenideElement header;
+	@FindBy(css = "input.toggle[type='checkbox']")
+	private SelenideElement checkbox;
+	@FindBy(css = "input.new-todo")
+	private SelenideElement newTodoInput;
+	@FindBy(css = "ul.todo-list>li")
+	private ElementsCollection todoList;
+	@FindBy(css = "ul.todo-list>li.editing>input.edit")
+	private SelenideElement todoListInput;
+	@FindBy(css = "button.destroy")
+	private SelenideElement xButton;
+	@FindBy(css = "ul.todo-list>li.completed")
+	private ElementsCollection completedTodoList;
+	@FindBy(css = "a[href='#/active']")
+	private SelenideElement activeLink;
+	@FindBy(css = "button.clear-completed")
+	private SelenideElement clearCompletedButton;
+
+	public void openTodomvcPage() {
+		openUrl(URL);
+		header.shouldHave(text("todos"));
+	}
+
+	public void createNewTodoItem(String todoText) {
+		setDataToField(newTodoInput, todoText, true);
+	}
+
+	public void deleteOneTodoItem() {
+		clickOnElement(todoList.first());
+		clickOnElement(xButton);
+	}
+
+	public void checkOneTodoItem() {
+		clickOnElement(todoList.first());
+		clickOnElement(checkbox);
+	}
+
+	public void clickActiveLink() {
+		clickOnElement(activeLink);
+	}
+
+	public void clickClearCompletedButton() {
+		clickOnElement(clearCompletedButton);
+	}
+
+	public String getLastTodoText() {
+		return todoList.last().getText();
+	}
+
+	public void editOneTodoItem(String todoText) {
+		clickOnElement(todoList.first());
+		$("ul.todo-list>li").doubleClick();
+		setDataToField(todoListInput, todoText, true);
+	}
+
+	public int getTodoListCount() {
+		return todoList.size();
+	}
+
+	public int getCompletedTodoListCount() {
+		return completedTodoList.size();
+	}
+
+	public String getFirstCompletedTodoItemTextStyle(String propertyName) {
+		return completedTodoList.first().find("div>label").getCssValue(propertyName);
+	}
+}

--- a/src/test/java/com/stepdefinitions/browser/BasicActionSteps.java
+++ b/src/test/java/com/stepdefinitions/browser/BasicActionSteps.java
@@ -1,0 +1,82 @@
+package com.stepdefinitions.browser;
+
+import com.page.TodomvcPage;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.testng.Assert;
+
+import static com.codeborne.selenide.Selenide.page;
+
+public class BasicActionSteps {
+	private final TodomvcPage todomvcPage = page(TodomvcPage.class);
+
+	@Given("I am a user of todomvc")
+	public void i_am_a_user_of_todomvc() {
+		todomvcPage.openTodomvcPage();
+	}
+
+	@And("I enter {int} todo items with description starting with {string}")
+	public void i_enter_todo_items(int todoItems, String description) {
+		for (int i = 0; i < todoItems; i++) {
+			todomvcPage.createNewTodoItem(description + i);
+		}
+	}
+
+	@When("I create a new todo item with description of {string}")
+	public void i_create_a_new_todo_item_with_description_of(String description) {
+		todomvcPage.createNewTodoItem(description);
+	}
+
+	@Then("it appears last on my todo list with description of {string}")
+	public void it_appears_last_on_my_todo_list_with_description_of(String description) {
+		String str = todomvcPage.getLastTodoText();
+		Assert.assertEquals(str, description);
+	}
+
+	@When("I edit a todo item with description of {string}")
+	public void i_edit_a_todo_item_with_description_of(String description) {
+		todomvcPage.editOneTodoItem(description);
+	}
+
+	@When("I delete a todo item using the red X button")
+	public void i_delete_a_todo_item_using_the_red_x_button() {
+		todomvcPage.deleteOneTodoItem();
+	}
+
+	@Then("the todo item is removed from my todo list of {int} items")
+	public void the_todo_item_is_removed_from_my_todo_list_of_items(int todoItems) {
+		Assert.assertTrue(todoItems - todomvcPage.getTodoListCount() <= 1, "should have deleted one item");
+	}
+
+	@When("I mark a todo item as completed")
+	public void i_mark_a_todo_item_as_completed() {
+		todomvcPage.checkOneTodoItem();
+	}
+
+	@Then("it is marked with a green checkmark")
+	public void it_is_marked_with_a_green_checkmark() {
+		Assert.assertTrue(todomvcPage.getCompletedTodoListCount() >= 1, "should have marked completed");
+	}
+
+	@And("it is crossed off my todo list with a Strikethrough")
+	public void it_is_crossed_off_my_todo_list_with_a_strikethrough() {
+		Assert.assertEquals(todomvcPage.getFirstCompletedTodoItemTextStyle("text-decoration-line"), "line-through");
+	}
+
+	@When("I click on the active link")
+	public void i_click_on_the_active_link() {
+		todomvcPage.clickActiveLink();
+	}
+
+	@Then("only Active todo items are shown")
+	public void only_Active_todo_items_are_shown() {
+		Assert.assertEquals(todomvcPage.getCompletedTodoListCount(), 0);
+	}
+
+	@When("I click Clear completed button")
+	public void i_click_Clear_completed_button() {
+		todomvcPage.clickClearCompletedButton();
+	}
+}

--- a/src/test/resources/features/httpbin/browser/TodomvcTests.feature
+++ b/src/test/resources/features/httpbin/browser/TodomvcTests.feature
@@ -1,0 +1,33 @@
+Feature: Basic todomvc features for tech interview
+
+  Background: go to todomvc page with some initial setup actions
+    Given I am a user of todomvc
+    And I enter 5 todo items with description starting with "my TODO item"
+
+
+  Scenario: verify new todo item appears last on my todo list
+    When I create a new todo item with description of "test new item"
+    Then it appears last on my todo list with description of "test new item"
+
+# TODO: edit not working
+  Scenario: verify todo item can be updated
+    When I edit a todo item with description of "my new edited item"
+
+  Scenario: verify delete a todo item
+    When I delete a todo item using the red X button
+    Then the todo item is removed from my todo list of 5 items
+
+  Scenario: verify complete a todo item
+    When I mark a todo item as completed
+    Then it is marked with a green checkmark
+    And it is crossed off my todo list with a Strikethrough
+
+  Scenario: verify active list item
+    Given I mark a todo item as completed
+    When I click on the active link
+    Then only Active todo items are shown
+
+  Scenario: verify clear completed todo items
+    Given I mark a todo item as completed
+    When I click Clear completed button
+    Then the todo item is removed from my todo list of 5 items


### PR DESCRIPTION
Completed all scenarios, except one that is to verify edit action
**Notes:**

- To make it simple, I put all in one page object, and all steps in one step definition file
  - but for refactoring purpose, it could be broken down further for more structure and readability. For example, the steps can have arrange file, actions file, assertion file, and etc
- Area for improvement: For the edit action, I'm not able to find the proper flow to double click and then edit with selenide (element state exception, which is probably why could try playwright or cypress instead)
- Area for improvement: when running the entire feature file (not the individual scenario one at a time), the "before"/background steps will continue to add staging data to the same session. Ideally, I'd want to create a new browser file/session for each scenario, but I'd spend more time to understand selenide with cucumber on how  to start a new profile each time
- Last scenario requirement (see below quote) needs some updates, as the "completed" items are actually removed after clicking "Clear Completed" (So there's nothing to be "moved to the Completed list")

> Given I have marked a todo item as complete
> When I click “Clear Completed”
> Then the completed todo item is removed from my todo list And the todo item is moved to the Completed list

```
Given I have marked a todo item as complete
When I click “Clear Completed” button
Then the completed todo item is removed from my todo list of {int} items